### PR TITLE
Update to refect new ESM

### DIFF
--- a/chatgpt-gnome-desktop@chatgpt-gnome-desktop/extension.js
+++ b/chatgpt-gnome-desktop@chatgpt-gnome-desktop/extension.js
@@ -15,11 +15,6 @@ export default class ChatGPTGnomeDesktopExtension extends Extension {
     }
 
     enable() {
-        if (this.initialized) {
-            log('Extension already initialized');
-            return;
-        }
-        this.initialized = true;
 
         log('Initializing extension');
         this.button = new St.Bin({

--- a/chatgpt-gnome-desktop@chatgpt-gnome-desktop/metadata.json
+++ b/chatgpt-gnome-desktop@chatgpt-gnome-desktop/metadata.json
@@ -3,7 +3,7 @@
     "description": "Access ChatGPT From Your Gnome-Desktop!",
     "version": "1.2",
     "uuid": "chatgpt-gnome-desktop@chatgpt-gnome-desktop",
-    "shell-version": ["46","47"],
+    "shell-version": ["46","47","48"],
     "url": "https://github.com/HorrorPills/ChatGPT-Gnome-Desktop-Extension",
     "author": "Rafal Mioduszewski"
 }

--- a/chatgpt-gnome-desktop@chatgpt-gnome-desktop/metadata.json
+++ b/chatgpt-gnome-desktop@chatgpt-gnome-desktop/metadata.json
@@ -3,7 +3,7 @@
     "description": "Access ChatGPT From Your Gnome-Desktop!",
     "version": "1.2",
     "uuid": "chatgpt-gnome-desktop@chatgpt-gnome-desktop",
-    "shell-version": ["41", "42", "43", "44", "45", "46","47"],
+    "shell-version": ["46","47"],
     "url": "https://github.com/HorrorPills/ChatGPT-Gnome-Desktop-Extension",
     "author": "Rafal Mioduszewski"
 }


### PR DESCRIPTION
Since the new ESM was not available in version's prior to Gnome 46 we need to make sure that the previous shell version's are removed.